### PR TITLE
Move dev mode capability to environment variable

### DIFF
--- a/server/routes/api/login.js
+++ b/server/routes/api/login.js
@@ -43,7 +43,7 @@ const secret = require("../../config/secret");
 /*
 developer mode
 */
-const developer = true;
+const developer = process.env.NODE_ENV !== 'production';
 
 /**
  * Route serving login form.


### PR DESCRIPTION
While in production the `NODE_ENV` environment variable will be set to `production`.  During development this value isn't set, so dev mode will automatically be on during development.