### PR TITLE
Use nodemon when running server in development

### DIFF
--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -11,4 +11,4 @@ COPY . .
 
 EXPOSE 9000
 
-CMD ["npm","start"]
+CMD ["npm","run","dev"]

--- a/server/package.json
+++ b/server/package.json
@@ -3,7 +3,8 @@
   "version": "0.0.0",
   "private": true,
   "scripts": {
-    "start": "node ./bin/www"
+    "start": "node ./bin/www",
+    "dev": "nodemon ./bin/www"
   },
   "dependencies": {
     "@sendgrid/mail": "^7.2.1",


### PR DESCRIPTION
Nodemon allows the server to restart when there are changes made to the code without having to rerun `npm start`. This change will make Docker use `npm run dev` instead of `npm start`