### PR TITLE
Fix scheduler showing wrong date on last step

### DIFF
--- a/client/src/components/clientFlow/4_selectDateTime.tsx
+++ b/client/src/components/clientFlow/4_selectDateTime.tsx
@@ -191,11 +191,7 @@ export const  Step4 = () => {
         let apptLoc = schedule.location;
         let apptSubj = schedule.title;
 
-        let apptDate = new Date(
-            startDay.getFullYear(),
-            startDay.getMonth(),
-            startDay.getDay()
-        ).toDateString();
+        let apptDate = new Date(startDay).toDateString();
 
         let apptStart = startDay.getTime();
         let apptEnd = endDay.getTime();


### PR DESCRIPTION
This fixes the bug where the date clicked on the scheduler was being displayed incorrectly in the final scheduling step